### PR TITLE
Fix path deprecation in Actions environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,16 @@
 # @engineerd/setup-kind
 
-Setup [KinD (Kubernetes in Docker)](https://kind.sigs.k8s.io/) with a single GitHub Action!
+Setup [KinD (Kubernetes in Docker)](https://kind.sigs.k8s.io/) with a single
+GitHub Action!
 
-> This action assumes a Linux environment, and will _not_ work on Windows or MacOS agents.
+> Because of a [deprecation in the GitHub Actions environment][gh-actions-path],
+> versions lower than v0.5.0 will no longer work properly. See [this
+> issue][path-issue] for more details.
 
-```
+> This action assumes a Linux environment, and will _not_ work on Windows or
+> MacOS agents.
+
+```yaml
 name: "Create cluster using KinD"
 on: [pull_request, push]
 
@@ -12,35 +18,42 @@ jobs:
   kind:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - uses: engineerd/setup-kind@v0.4.0
-    - name: Testing
-      run: |
-        kubectl cluster-info
-        kubectl get pods -n kube-system
-        echo "current-context:" $(kubectl config current-context)
-        echo "environment-kubeconfig:" ${KUBECONFIG}
+      - uses: actions/checkout@master
+      - uses: engineerd/setup-kind@v0.5.0
+      - name: Testing
+        run: |
+          kubectl cluster-info
+          kubectl get pods -n kube-system
+          echo "current-context:" $(kubectl config current-context)
+          echo "environment-kubeconfig:" ${KUBECONFIG}
 ```
 
-> Note: KUBECONFIG is automatically merged after cluster creation starting with version 0.6 of Kind. See [this document for a detailed migration guide][kind-kubeconfig]
+> Note: KUBECONFIG is automatically merged after cluster creation starting with
+> version 0.6 of Kind. See [this document for a detailed migration
+> guide][kind-kubeconfig]
 
 > Note: GitHub Actions workers come pre-configured with `kubectl`.
 
-The following arguments can be configured on the job using the `with` keyword (see example above).
-Currently, possible inputs are all the flags for `kind cluster create`, with the additional version, which sets the Kind version to downloadm and `skipClusterCreation`, which when present, skips creating the cluster (the Kind tools is configured in the path).
+The following arguments can be configured on the job using the `with` keyword
+(see example above). Currently, possible inputs are all the flags for
+`kind cluster create`, with the additional version, which sets the Kind version
+to downloadm and `skipClusterCreation`, which when present, skips creating the
+cluster (the Kind tools is configured in the path).
 
 Optional inputs:
 
 - `version`: version of Kind to use (default `"v0.7.0"`)
-- `config`: path (relative to the root of the repository) to a kind config file. If omitted, a default 1-node cluster will be created
+- `config`: path (relative to the root of the repository) to a kind config file.
+  If omitted, a default 1-node cluster will be created
 - `image`: node Docker image to use for booting the cluster.
 - `name`: cluster context name (default `"kind-kind"`)
 - `wait`: wait for control plane node to be ready (default `"300s"`)
-- `skipClusterCreation`: if `"true"`, the action will not create a cluster, just acquire the tools
+- `skipClusterCreation`: if `"true"`, the action will not create a cluster, just
+  acquire the tools
 
 Example using optional inputs:
 
-```
+```yaml
 name: "Create cluster using KinD"
 on: [pull_request, push]
 
@@ -48,16 +61,19 @@ jobs:
   kind:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - uses: engineerd/setup-kind@v0.4.0
-      with:
+      - uses: actions/checkout@master
+      - uses: engineerd/setup-kind@v0.5.0
+        with:
           version: "v0.7.0"
-    - name: Testing
-      run: |
-        kubectl cluster-info
-        kubectl get pods -n kube-system
-        echo "current-context:" $(kubectl config current-context)
-        echo "environment-kubeconfig:" ${KUBECONFIG}
+      - name: Testing
+        run: |
+          kubectl cluster-info
+          kubectl get pods -n kube-system
+          echo "current-context:" $(kubectl config current-context)
+          echo "environment-kubeconfig:" ${KUBECONFIG}
 ```
 
 [kind-kubeconfig]: https://github.com/kubernetes-sigs/kind/issues/1060
+[gh-actions-path]:
+  https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
+[path-issue]: https://github.com/engineerd/setup-kind/issues/28

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@actions/core": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.4.tgz",
-      "integrity": "sha512-YJCEq8BE3CdN8+7HPZ/4DxJjk/OkZV2FFIf+DlZTC/4iBlzYCD5yjRR6eiOS5llO11zbRltIRuKAjMKaWTE6cg=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.6.tgz",
+      "integrity": "sha512-ZQYitnqiyBc3D+k7LsgSBmMDVkOVidaagDG7j3fOym77jNunWRuYx7VSHa9GNfFZh+zh61xsCjRj4JxMZlDqTA=="
     },
     "@actions/exec": {
       "version": "1.0.4",
@@ -18,9 +18,9 @@
       }
     },
     "@actions/http-client": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-1.0.8.tgz",
-      "integrity": "sha512-G4JjJ6f9Hb3Zvejj+ewLLKLf99ZC+9v+yCxoYf9vSyH+WkzPLB2LuUtRMGNkooMqdugGBFStIKXOuvH1W+EctA==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-1.0.9.tgz",
+      "integrity": "sha512-0O4SsJ7q+MK0ycvXPl2e6bMXV7dxAXOGjrXS1eTF9s2S401Tp6c/P3c3Joz04QefC1J6Gt942Wl2jbm3f4mLcg==",
       "requires": {
         "tunnel": "0.0.6"
       }
@@ -31,9 +31,9 @@
       "integrity": "sha512-J8KuFqVPr3p6U8W93DOXlXW6zFvrQAJANdS+vw0YhusLIq+bszW8zmK2Fh1C2kDPX8FMvwIl1OUcFgvJoXLbAg=="
     },
     "@actions/tool-cache": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/@actions/tool-cache/-/tool-cache-1.5.5.tgz",
-      "integrity": "sha512-y/YO37BOaXzOEHpvoGZDLCwvg6XZWQ7Ala4Np4xzrKD1r48mff+K/GAmzXMejnApU7kgqC6lL/aCKTZDCrhdmw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@actions/tool-cache/-/tool-cache-1.6.0.tgz",
+      "integrity": "sha512-+fyEBImPD3m5I0o6DflCO0NHY180LPoX8Lo6y4Iez+V17kO8kfkH0VHxb8mUdmD6hn9dWA9Ch1JA20fXoIYUeQ==",
       "requires": {
         "@actions/core": "^1.2.3",
         "@actions/exec": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-kind",
-  "version": "0.1.0",
+  "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -596,9 +596,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
       "dev": true
     },
     "log-symbols": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-kind",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "description": "GitHub Action to setup KinD (Kubernetes in Docker)",
   "main": "lib/main.js",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   "author": "Engineerd",
   "license": "MIT",
   "dependencies": {
-    "@actions/core": "^1.2.4",
-    "@actions/tool-cache": "^1.5.5",
+    "@actions/core": "^1.2.6",
+    "@actions/tool-cache": "^1.6.0",
     "@actions/exec": "^1.0.4"
   },
   "devDependencies": {


### PR DESCRIPTION
closes #28 

As described in #28 and in the [GitHub deprecation notice](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/), the implementation of `core.addPath`  used by this action will no longer be supported.

This PR updates the `@actions`, and specifically the `@actions/core` package to version `1.2.6`, which contains an updated implementation for `addPath` .