### PR TITLE
support linux/arm64 and add state verifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ GitHub Action!
 > versions lower than v0.5.0 will no longer work properly. See [this
 > issue][path-issue] for more details.
 
-> This action assumes a Linux environment (amd64 or arm64 architectures), and will _not_ work on Windows or
+> This action assumes a Linux environment (amd64 or arm64 architecture), and will _not_ work on Windows or
 > MacOS agents.
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ GitHub Action!
 > versions lower than v0.5.0 will no longer work properly. See [this
 > issue][path-issue] for more details.
 
-> This action assumes a Linux environment, and will _not_ work on Windows or
+> This action assumes a Linux environment (amd64 or arm64 architectures), and will _not_ work on Windows or
 > MacOS agents.
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ Optional inputs:
 - `skipClusterLogsExport`: if `"true"`, the action will not export the cluster logs
 - `verbosity`: numeric log verbosity, (info = 0, debug = 3, trace = 2147483647) (default `"0"`)
 - `quiet`: silence all stderr output (default `"false"`)
-  
 
 Example using optional inputs:
 

--- a/__tests__/kind/post.test.ts
+++ b/__tests__/kind/post.test.ts
@@ -1,4 +1,3 @@
-import os from 'os';
 import path from 'path';
 import { KindPostService } from '../../src/kind/post';
 
@@ -7,7 +6,8 @@ const testEnvVars = {
   INPUT_QUIET: 'true',
   INPUT_NAME: 'some-name',
   INPUT_KUBECONFIG: 'some-kubeconfig-path',
-  GITHUB_WORKSPACE: '/home/runner/repo',
+  GITHUB_JOB: 'kind',
+  RUNNER_TEMP: '/home/runner/work/_temp/',
 };
 
 describe('checking input parsing', function () {
@@ -58,7 +58,9 @@ describe('checking input parsing', function () {
     expect(args).toEqual([
       'export',
       'logs',
-      path.join(os.tmpdir(), 'kind/some-name/logs'),
+      path.normalize(
+        '/home/runner/work/_temp/1c1900ec-8f4f-5069-a966-1d3072cc9723'
+      ),
       '--verbosity',
       testEnvVars.INPUT_VERBOSITY,
       '--quiet',

--- a/__tests__/kind/post.test.ts
+++ b/__tests__/kind/post.test.ts
@@ -5,7 +5,6 @@ import { KindPostService } from '../../src/kind/post';
 const testEnvVars = {
   INPUT_VERBOSITY: '3',
   INPUT_QUIET: 'true',
-  INPUT_CONFIG: 'some-path',
   INPUT_NAME: 'some-name',
   INPUT_KUBECONFIG: 'some-kubeconfig-path',
   GITHUB_WORKSPACE: '/home/runner/repo',
@@ -27,13 +26,12 @@ describe('checking input parsing', function () {
 
   it('correctly parse input', () => {
     const service: KindPostService = KindPostService.getInstance();
-    expect(service.configFile).toEqual(testEnvVars.INPUT_CONFIG);
     expect(service.kubeConfigFile).toEqual(testEnvVars.INPUT_KUBECONFIG);
     expect(service.skipClusterDeletion).toEqual(false);
     expect(service.skipClusterLogsExport).toEqual(false);
   });
 
-  it('correctly set skipClusterCreation', () => {
+  it('correctly set skipClusterDeletion', () => {
     process.env['INPUT_SKIPCLUSTERDELETION'] = 'true';
     const service: KindPostService = KindPostService.getInstance();
     expect(service.skipClusterDeletion).toEqual(true);

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,7 @@ inputs:
   version:
     description: "Version of Kind to use (default v0.11.1)"
     default: "v0.11.1"
+    required: true
   config:
     description: "Path (relative to the root of the repository) to a kind config file"
   image:
@@ -12,11 +13,12 @@ inputs:
   name:
     description: "Cluster name (default kind)"
     default: "kind"
+    required: true
   wait:
     description: "Wait for control plane node to be ready (default 300s)"
     default: "300s"
   kubeconfig:
-    description: "sets kubeconfig path instead of $KUBECONFIG or $HOME/.kube/config"
+    description: "Sets kubeconfig path instead of $KUBECONFIG or $HOME/.kube/config"
   skipClusterCreation:
     description: "If true, the action will not create a cluster, just acquire the tools"
     default: "false"

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,11 +14,14 @@
         "@actions/core": "^1.6.0",
         "@actions/exec": "^1.1.0",
         "@actions/glob": "^0.2.0",
-        "@actions/tool-cache": "^1.7.1"
+        "@actions/io": "^1.1.1",
+        "@actions/tool-cache": "^1.7.1",
+        "semver": "^7.3.5"
       },
       "devDependencies": {
         "@types/jest": "^27.4.0",
         "@types/node": "^17.0.6",
+        "@types/semver": "^7.3.9",
         "@typescript-eslint/eslint-plugin": "^5.8.1",
         "@typescript-eslint/parser": "^5.8.1",
         "@vercel/ncc": "^0.33.1",
@@ -71,6 +74,14 @@
         "minimatch": "^3.0.4"
       }
     },
+    "node_modules/@actions/cache/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/@actions/core": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.6.0.tgz",
@@ -113,9 +124,9 @@
       }
     },
     "node_modules/@actions/io": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.0.2.tgz",
-      "integrity": "sha512-J8KuFqVPr3p6U8W93DOXlXW6zFvrQAJANdS+vw0YhusLIq+bszW8zmK2Fh1C2kDPX8FMvwIl1OUcFgvJoXLbAg=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.1.tgz",
+      "integrity": "sha512-Qi4JoKXjmE0O67wAOH6y0n26QXhMKMFo7GD/4IXNVcrtLjUlGjGuVys6pQgwF3ArfGTQu0XpqaNr0YhED2RaRA=="
     },
     "node_modules/@actions/tool-cache": {
       "version": "1.7.1",
@@ -130,10 +141,13 @@
         "uuid": "^3.3.2"
       }
     },
-    "node_modules/@actions/tool-cache/node_modules/@actions/io": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.1.tgz",
-      "integrity": "sha512-Qi4JoKXjmE0O67wAOH6y0n26QXhMKMFo7GD/4IXNVcrtLjUlGjGuVys6pQgwF3ArfGTQu0XpqaNr0YhED2RaRA=="
+    "node_modules/@actions/tool-cache/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
     },
     "node_modules/@azure/abort-controller": {
       "version": "1.0.4",
@@ -417,6 +431,15 @@
         "url": "https://opencollective.com/babel"
       }
     },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/@babel/core/node_modules/source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -465,6 +488,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/helper-environment-visitor": {
@@ -1566,6 +1598,12 @@
       "integrity": "sha512-ekoj4qOQYp7CvjX8ZDBgN86w3MqQhLE1hczEJbEIjgFEumDy+na/4AJAbLXfgEWFNB2pKadM5rPFtuSGMWK7xA==",
       "dev": true
     },
+    "node_modules/@types/semver": {
+      "version": "7.3.9",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.9.tgz",
+      "integrity": "sha512-L/TMpyURfBkf+o/526Zb6kd/tchUP3iBDEPjqjb+U2MAJhVRxxrmr2fwpe08E7QsV7YLcpq0tUaQ9O9x97ZIxQ==",
+      "dev": true
+    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
@@ -1625,21 +1663,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@typescript-eslint/experimental-utils": {
@@ -1748,21 +1771,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
@@ -2070,6 +2078,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/babel-plugin-istanbul/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/babel-plugin-jest-hoist": {
@@ -3000,21 +3017,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/eslint/node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/espree": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.0.tgz",
@@ -3732,6 +3734,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/istanbul-lib-instrument/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/istanbul-lib-report": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
@@ -4311,21 +4322,6 @@
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
     },
-    "node_modules/jest-snapshot/node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/jest-util": {
       "version": "27.4.2",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-27.4.2.tgz",
@@ -4728,7 +4724,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -4749,6 +4744,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/make-error": {
@@ -5444,11 +5448,17 @@
       }
     },
     "node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
       "bin": {
         "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/shebang-command": {
@@ -5866,21 +5876,6 @@
         }
       }
     },
-    "node_modules/ts-jest/node_modules/semver": {
-      "version": "7.3.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-      "dev": true,
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/ts-node": {
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.4.0.tgz",
@@ -6260,8 +6255,7 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yaml": {
       "version": "1.10.2",
@@ -6345,6 +6339,11 @@
             "@actions/core": "^1.2.6",
             "minimatch": "^3.0.4"
           }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
       }
     },
@@ -6392,9 +6391,9 @@
       }
     },
     "@actions/io": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.0.2.tgz",
-      "integrity": "sha512-J8KuFqVPr3p6U8W93DOXlXW6zFvrQAJANdS+vw0YhusLIq+bszW8zmK2Fh1C2kDPX8FMvwIl1OUcFgvJoXLbAg=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.1.tgz",
+      "integrity": "sha512-Qi4JoKXjmE0O67wAOH6y0n26QXhMKMFo7GD/4IXNVcrtLjUlGjGuVys6pQgwF3ArfGTQu0XpqaNr0YhED2RaRA=="
     },
     "@actions/tool-cache": {
       "version": "1.7.1",
@@ -6409,10 +6408,10 @@
         "uuid": "^3.3.2"
       },
       "dependencies": {
-        "@actions/io": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/@actions/io/-/io-1.1.1.tgz",
-          "integrity": "sha512-Qi4JoKXjmE0O67wAOH6y0n26QXhMKMFo7GD/4IXNVcrtLjUlGjGuVys6pQgwF3ArfGTQu0XpqaNr0YhED2RaRA=="
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
         }
       }
     },
@@ -6664,6 +6663,12 @@
         "source-map": "^0.5.0"
       },
       "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -6701,6 +6706,14 @@
         "@babel/helper-validator-option": "^7.16.7",
         "browserslist": "^4.17.5",
         "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
       }
     },
     "@babel/helper-environment-visitor": {
@@ -7584,6 +7597,12 @@
       "integrity": "sha512-ekoj4qOQYp7CvjX8ZDBgN86w3MqQhLE1hczEJbEIjgFEumDy+na/4AJAbLXfgEWFNB2pKadM5rPFtuSGMWK7xA==",
       "dev": true
     },
+    "@types/semver": {
+      "version": "7.3.9",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.9.tgz",
+      "integrity": "sha512-L/TMpyURfBkf+o/526Zb6kd/tchUP3iBDEPjqjb+U2MAJhVRxxrmr2fwpe08E7QsV7YLcpq0tUaQ9O9x97ZIxQ==",
+      "dev": true
+    },
     "@types/stack-utils": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
@@ -7627,17 +7646,6 @@
         "regexpp": "^3.2.0",
         "semver": "^7.3.5",
         "tsutils": "^3.21.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
       }
     },
     "@typescript-eslint/experimental-utils": {
@@ -7695,17 +7703,6 @@
         "is-glob": "^4.0.3",
         "semver": "^7.3.5",
         "tsutils": "^3.21.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
       }
     },
     "@typescript-eslint/visitor-keys": {
@@ -7930,6 +7927,12 @@
             "istanbul-lib-coverage": "^3.2.0",
             "semver": "^6.3.0"
           }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
         }
       }
     },
@@ -8562,15 +8565,6 @@
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
           "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
           "dev": true
-        },
-        "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
         }
       }
     },
@@ -9159,6 +9153,14 @@
         "@istanbuljs/schema": "^0.1.2",
         "istanbul-lib-coverage": "^3.0.0",
         "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
       }
     },
     "istanbul-lib-report": {
@@ -9614,17 +9616,6 @@
         "natural-compare": "^1.4.0",
         "pretty-format": "^27.4.2",
         "semver": "^7.3.2"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
       }
     },
     "jest-util": {
@@ -9927,7 +9918,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -9939,6 +9929,14 @@
       "dev": true,
       "requires": {
         "semver": "^6.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
       }
     },
     "make-error": {
@@ -10453,9 +10451,12 @@
       }
     },
     "semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+      "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
     },
     "shebang-command": {
       "version": "2.0.0",
@@ -10752,17 +10753,6 @@
         "make-error": "1.x",
         "semver": "7.x",
         "yargs-parser": "20.x"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.3.5",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-          "integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
       }
     },
     "ts-node": {
@@ -11036,8 +11026,7 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yaml": {
       "version": "1.10.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,12 +16,14 @@
         "@actions/glob": "^0.2.0",
         "@actions/io": "^1.1.1",
         "@actions/tool-cache": "^1.7.1",
-        "semver": "^7.3.5"
+        "semver": "^7.3.5",
+        "uuid": "^8.3.2"
       },
       "devDependencies": {
         "@types/jest": "^27.4.0",
         "@types/node": "^17.0.6",
         "@types/semver": "^7.3.9",
+        "@types/uuid": "^8.3.4",
         "@typescript-eslint/eslint-plugin": "^5.8.1",
         "@typescript-eslint/parser": "^5.8.1",
         "@vercel/ncc": "^0.33.1",
@@ -80,6 +82,15 @@
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@actions/cache/node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "bin": {
+        "uuid": "bin/uuid"
       }
     },
     "node_modules/@actions/core": {
@@ -147,6 +158,15 @@
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@actions/tool-cache/node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "bin": {
+        "uuid": "bin/uuid"
       }
     },
     "node_modules/@azure/abort-controller": {
@@ -229,14 +249,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
-    },
-    "node_modules/@azure/core-http/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
     },
     "node_modules/@azure/core-lro": {
       "version": "2.2.2",
@@ -347,14 +359,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/@azure/ms-rest-js/node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@azure/storage-blob": {
@@ -1617,6 +1621,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
+      "dev": true
     },
     "node_modules/@types/yargs": {
       "version": "16.0.4",
@@ -6027,12 +6037,11 @@
       }
     },
     "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "bin": {
-        "uuid": "bin/uuid"
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache": {
@@ -6344,6 +6353,11 @@
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
         }
       }
     },
@@ -6412,6 +6426,11 @@
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
         }
       }
     },
@@ -6487,11 +6506,6 @@
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
           "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
-        },
-        "uuid": {
-          "version": "8.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
         }
       }
     },
@@ -6595,11 +6609,6 @@
             "psl": "^1.1.28",
             "punycode": "^2.1.1"
           }
-        },
-        "uuid": {
-          "version": "8.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-          "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
         }
       }
     },
@@ -7616,6 +7625,12 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/uuid": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
+      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
+      "dev": true
     },
     "@types/yargs": {
       "version": "16.0.4",
@@ -10853,9 +10868,9 @@
       }
     },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-compile-cache": {
       "version": "2.3.0",

--- a/package.json
+++ b/package.json
@@ -38,12 +38,14 @@
     "@actions/glob": "^0.2.0",
     "@actions/io": "^1.1.1",
     "@actions/tool-cache": "^1.7.1",
-    "semver": "^7.3.5"
+    "semver": "^7.3.5",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^17.0.6",
     "@types/semver": "^7.3.9",
+    "@types/uuid": "^8.3.4",
     "@typescript-eslint/eslint-plugin": "^5.8.1",
     "@typescript-eslint/parser": "^5.8.1",
     "@vercel/ncc": "^0.33.1",

--- a/package.json
+++ b/package.json
@@ -36,11 +36,14 @@
     "@actions/core": "^1.6.0",
     "@actions/exec": "^1.1.0",
     "@actions/glob": "^0.2.0",
-    "@actions/tool-cache": "^1.7.1"
+    "@actions/io": "^1.1.1",
+    "@actions/tool-cache": "^1.7.1",
+    "semver": "^7.3.5"
   },
   "devDependencies": {
     "@types/jest": "^27.4.0",
     "@types/node": "^17.0.6",
+    "@types/semver": "^7.3.9",
     "@typescript-eslint/eslint-plugin": "^5.8.1",
     "@typescript-eslint/parser": "^5.8.1",
     "@vercel/ncc": "^0.33.1",

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -3,15 +3,16 @@ import * as core from '@actions/core';
 import crypto from 'crypto';
 import path from 'path';
 import process from 'process';
+import { KIND_TOOL_NAME } from './constants';
 
 const KIND_CACHE_PATHS = [
-  path.join(`${process.env['RUNNER_TOOL_CACHE']}`, 'kind'),
+  path.join(`${process.env['RUNNER_TOOL_CACHE']}`, KIND_TOOL_NAME),
 ];
 
 const KIND_CACHE_KEY_PREFIX = `${process.env['RUNNER_OS']}-${process.env['RUNNER_ARCH']}-setup-kind-`;
 
 /**
- * Restores Kind by version, $RUNNER_OS and $RUNNER_ARCh
+ * Restores Kind by version, $RUNNER_OS and $RUNNER_ARCH
  * @param version
  */
 export async function restoreKindCache(version: string) {

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -3,40 +3,81 @@ import * as core from '@actions/core';
 import crypto from 'crypto';
 import path from 'path';
 import process from 'process';
+import * as semver from 'semver';
 import { KIND_TOOL_NAME } from './constants';
 
-const KIND_CACHE_PATHS = [
-  path.join(`${process.env['RUNNER_TOOL_CACHE']}`, KIND_TOOL_NAME),
-];
-
+/**
+ *  Prefix of the kind cache key
+ */
 const KIND_CACHE_KEY_PREFIX = `${process.env['RUNNER_OS']}-${process.env['RUNNER_ARCH']}-setup-kind-`;
+
+/**
+ * Parameters used by the cache to save and restore
+ */
+export interface CacheParameters {
+  /**
+   * a list of file paths to restore from the cache
+   */
+  paths: string[];
+  /**
+   * An explicit key for restoring the cache
+   */
+  primaryKey: string;
+}
 
 /**
  * Restores Kind by version, $RUNNER_OS and $RUNNER_ARCH
  * @param version
  */
-export async function restoreKindCache(version: string) {
+export async function restoreKindCache(
+  version: string
+): Promise<CacheParameters> {
   const primaryKey = kindPrimaryKey(version);
+  const cachePaths = kindCachePaths(version);
 
   core.debug(`Primary key is ${primaryKey}`);
 
-  const matchedKey = await cache.restoreCache(KIND_CACHE_PATHS, primaryKey);
+  const matchedKey = await cache.restoreCache(cachePaths, primaryKey);
 
   if (matchedKey) {
     core.info(`Cache setup-kind restored from key: ${matchedKey}`);
   } else {
     core.info('Cache setup-kind is not found');
   }
-  return primaryKey;
+  return {
+    paths: cachePaths,
+    primaryKey: primaryKey,
+  };
 }
 /**
+ * Defines the cache paths
+ * It is the folder where kind will be stored in the tool-cache
+ * per it's version and process architecture
+ * @param version
+ * @returns the cache paths
+ */
+function kindCachePaths(version: string) {
+  return [
+    path.join(
+      `${process.env['RUNNER_TOOL_CACHE']}`,
+      KIND_TOOL_NAME,
+      semver.clean(version) || version
+    ),
+  ];
+}
+
+/**
  * Defines a primary Key for the kind cache.
- * It is the concatenation of the $RUNNER_OS, the $RUNNER_ARCH and the hexadecimal value of the sha256 of the version
+ * It is the concatenation of the $RUNNER_OS, the $RUNNER_ARCH
+ * and the hexadecimal value of the sha256 of the version
  * @param version
  * @returns the primary Key
  */
 function kindPrimaryKey(version: string) {
-  const hash = crypto.createHash('sha256').update(version).digest('hex');
+  const hash = crypto
+    .createHash('sha256')
+    .update(`kind-${version}-${process.platform}-${process.arch}-`)
+    .digest('hex');
   return `${KIND_CACHE_KEY_PREFIX}${hash}`;
 }
 
@@ -44,10 +85,10 @@ function kindPrimaryKey(version: string) {
  * Caches Kind by it's primaryKey
  * @param primaryKey
  */
-export async function saveKindCache(primaryKey: string) {
+export async function saveKindCache(parameters: CacheParameters) {
   try {
-    await cache.saveCache(KIND_CACHE_PATHS, primaryKey);
-    core.info(`Cache setup-kind saved with the key ${primaryKey}`);
+    await cache.saveCache(parameters.paths, parameters.primaryKey);
+    core.info(`Cache setup-kind saved with the key ${parameters.primaryKey}`);
   } catch (err) {
     const error = err as Error;
     if (error.name === cache.ValidationError.name) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -24,3 +24,5 @@ export enum Flag {
 }
 
 export const KIND_TOOL_NAME = 'kind';
+
+export const KIND_DEFAULT_VERSION = 'v0.11.1';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -22,3 +22,5 @@ export enum Flag {
   Wait = '--wait',
   KubeConfig = '--kubeconfig',
 }
+
+export const KIND_TOOL_NAME = 'kind';

--- a/src/kind/core.ts
+++ b/src/kind/core.ts
@@ -4,6 +4,5 @@ import process from 'process';
 export const KIND_COMMAND = process.platform === 'win32' ? 'kind.exe' : 'kind';
 
 export async function executeKindCommand(args: string[]) {
-  console.log(`Executing ${KIND_COMMAND} with args ` + args.join(' '));
   await exec.exec(KIND_COMMAND, args);
 }

--- a/src/kind/core.ts
+++ b/src/kind/core.ts
@@ -1,12 +1,9 @@
 import * as exec from '@actions/exec';
 import process from 'process';
 
-export function kindCommand(): string {
-  return process.platform == 'win32' ? 'kind.exe' : 'kind';
-}
+export const KIND_COMMAND = process.platform === 'win32' ? 'kind.exe' : 'kind';
 
 export async function executeKindCommand(args: string[]) {
-  const command = kindCommand();
-  console.log(`Executing ${command} with args ` + args.join(' '));
-  await exec.exec(command, args);
+  console.log(`Executing ${KIND_COMMAND} with args ` + args.join(' '));
+  await exec.exec(KIND_COMMAND, args);
 }

--- a/src/kind/main.ts
+++ b/src/kind/main.ts
@@ -20,11 +20,11 @@ export class KindMainService {
   quiet: boolean;
 
   private constructor() {
-    this.version = core.getInput(Input.Version);
+    this.version = core.getInput(Input.Version, { required: true });
     this.configFile = core.getInput(Input.Config);
     this.image = core.getInput(Input.Image);
     this.checkImage();
-    this.name = core.getInput(Input.Name);
+    this.name = core.getInput(Input.Name, { required: true });
     this.waitDuration = core.getInput(Input.Wait);
     this.kubeConfigFile = core.getInput(Input.KubeConfig);
     this.skipClusterCreation =

--- a/src/kind/main.ts
+++ b/src/kind/main.ts
@@ -5,10 +5,8 @@ import path from 'path';
 import process from 'process';
 import * as go from '../go';
 import * as cache from '../cache';
-import { Input, Flag } from '../constants';
+import { Input, Flag, KIND_TOOL_NAME } from '../constants';
 import { kindCommand, executeKindCommand } from './core';
-
-const toolName = 'kind';
 
 export class KindMainService {
   version: string;
@@ -81,7 +79,7 @@ export class KindMainService {
     const toolPath: string = await tc.cacheFile(
       downloadPath,
       kindCommand(),
-      toolName,
+      KIND_TOOL_NAME,
       this.version
     );
     core.debug(`kind is cached under ${toolPath}`);
@@ -90,7 +88,7 @@ export class KindMainService {
 
   async installKind(): Promise<string> {
     const primaryKey = await cache.restoreKindCache(this.version);
-    let toolPath: string = tc.find(toolName, this.version);
+    let toolPath: string = tc.find(KIND_TOOL_NAME, this.version);
     if (toolPath === '') {
       toolPath = await this.downloadKind();
       await cache.saveKindCache(primaryKey);

--- a/src/kind/main.ts
+++ b/src/kind/main.ts
@@ -23,6 +23,7 @@ export class KindMainService {
     this.version = core.getInput(Input.Version);
     this.configFile = core.getInput(Input.Config);
     this.image = core.getInput(Input.Image);
+    this.checkImage();
     this.name = core.getInput(Input.Name);
     this.waitDuration = core.getInput(Input.Wait);
     this.kubeConfigFile = core.getInput(Input.KubeConfig);
@@ -34,6 +35,22 @@ export class KindMainService {
 
   public static getInstance(): KindMainService {
     return new KindMainService();
+  }
+
+  /**
+   * Prints a warning if a kindest/node is used without sha256.
+   * This follows https://kind.sigs.k8s.io/docs/user/working-offline/#using-a-prebuilt-node-imagenode-image recommendation
+   */
+  private checkImage() {
+    if (
+      this.image !== '' &&
+      this.image.startsWith('kindest/node') &&
+      !this.image.includes('@sha256:')
+    ) {
+      core.warning(
+        `Please include the @sha256: image digest from the image in the release notes. You can find available image tags on the release page, https://github.com/kubernetes-sigs/kind/releases/tag/${this.version}`
+      );
+    }
   }
 
   // returns the arguments to pass to `kind create cluster`

--- a/src/kind/post.ts
+++ b/src/kind/post.ts
@@ -7,7 +7,6 @@ import { Input, Flag, KIND_TOOL_NAME } from '../constants';
 import { executeKindCommand } from './core';
 
 export class KindPostService {
-  configFile: string;
   name: string;
   kubeConfigFile: string;
   skipClusterDeletion: boolean;
@@ -16,7 +15,6 @@ export class KindPostService {
   quiet: boolean;
 
   private constructor() {
-    this.configFile = core.getInput(Input.Config);
     this.name = core.getInput(Input.Name);
     this.kubeConfigFile = core.getInput(Input.KubeConfig);
     this.skipClusterDeletion =

--- a/src/kind/post.ts
+++ b/src/kind/post.ts
@@ -3,7 +3,7 @@ import * as core from '@actions/core';
 import * as glob from '@actions/glob';
 import os from 'os';
 import path from 'path';
-import { Input, Flag, KIND_TOOL_NAME } from '../constants';
+import { Flag, Input, KIND_TOOL_NAME } from '../constants';
 import { executeKindCommand } from './core';
 
 export class KindPostService {

--- a/src/kind/post.ts
+++ b/src/kind/post.ts
@@ -3,7 +3,7 @@ import * as core from '@actions/core';
 import * as glob from '@actions/glob';
 import os from 'os';
 import path from 'path';
-import { Input, Flag } from '../constants';
+import { Input, Flag, KIND_TOOL_NAME } from '../constants';
 import { executeKindCommand } from './core';
 
 export class KindPostService {
@@ -65,7 +65,7 @@ export class KindPostService {
   }
 
   private kindLogsDir(): string {
-    const dirs: string[] = ['kind'];
+    const dirs: string[] = [KIND_TOOL_NAME];
     if (this.name != '') {
       dirs.push(this.name);
     }
@@ -74,7 +74,7 @@ export class KindPostService {
   }
 
   private artifactName(): string {
-    const artifactArgs: string[] = ['kind'];
+    const artifactArgs: string[] = [KIND_TOOL_NAME];
     if (this.name != '') {
       artifactArgs.push(this.name);
     }

--- a/src/kind/post.ts
+++ b/src/kind/post.ts
@@ -72,7 +72,10 @@ export class KindPostService {
   }
 
   private artifactName(): string {
-    const artifactArgs: string[] = [KIND_TOOL_NAME];
+    const artifactArgs: string[] = [
+      `${process.env['GITHUB_JOB']}`,
+      KIND_TOOL_NAME,
+    ];
     if (this.name != '') {
       artifactArgs.push(this.name);
     }

--- a/src/kind/post.ts
+++ b/src/kind/post.ts
@@ -1,8 +1,9 @@
 import * as artifact from '@actions/artifact';
 import * as core from '@actions/core';
 import * as glob from '@actions/glob';
-import os from 'os';
 import path from 'path';
+import process from 'process';
+import { v5 as uuidv5 } from 'uuid';
 import { Flag, Input, KIND_TOOL_NAME } from '../constants';
 import { executeKindCommand } from './core';
 
@@ -68,7 +69,10 @@ export class KindPostService {
       dirs.push(this.name);
     }
     dirs.push('logs');
-    return path.join(os.tmpdir(), ...dirs);
+    return path.join(
+      `${process.env['RUNNER_TEMP']}`,
+      uuidv5(dirs.join('/'), uuidv5.URL)
+    );
   }
 
   private artifactName(): string {

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,7 +15,7 @@ async function run() {
 }
 
 function checkEnvironment() {
-  const supportedPlatforms: string[] = ['linux/amd64'];
+  const supportedPlatforms: string[] = ['linux/amd64', 'linux/arm64'];
   const platform = `${go.goos()}/${go.goarch()}`;
   if (!supportedPlatforms.includes(platform)) {
     throw new Error(`Platform "${platform}" is not supported`);

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,9 +18,10 @@ async function run() {
 function checkEnvironment() {
   const supportedPlatforms: string[] = ['linux/amd64', 'linux/arm64'];
   const platform = `${go.goos()}/${go.goarch()}`;
-  if (!supportedPlatforms.includes(platform)) {
-    throw new Error(`Platform "${platform}" is not supported`);
-  }
+  ok(
+    supportedPlatforms.includes(platform),
+    `Platform "${platform}" is not supported`
+  );
   const requiredVariables = [
     'GITHUB_WORKSPACE',
     'RUNNER_ARCH',

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,6 +28,7 @@ function checkEnvironment() {
     'GITHUB_WORKSPACE',
     'RUNNER_ARCH',
     'RUNNER_OS',
+    'RUNNER_TEMP',
     'RUNNER_TOOL_CACHE',
   ];
   requiredVariables.forEach((variable) => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -24,6 +24,7 @@ function checkEnvironment() {
     `Platform "${platform}" is not supported`
   );
   const requiredVariables = [
+    'GITHUB_JOB',
     'GITHUB_WORKSPACE',
     'RUNNER_ARCH',
     'RUNNER_OS',

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 import * as core from '@actions/core';
+import * as io from '@actions/io';
 import { ok } from 'assert';
 import * as go from './go';
 import { KindMainService } from './kind/main';
@@ -31,6 +32,8 @@ function checkEnvironment() {
   requiredVariables.forEach((variable) => {
     ok(`${process.env[variable]}`, `Expected ${variable} to be defined`);
   });
+  const docker = io.which('docker', false);
+  ok(docker, 'Docker is required for kind use');
 }
 
 run();

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,5 @@
 import * as core from '@actions/core';
+import { ok } from 'assert';
 import * as go from './go';
 import { KindMainService } from './kind/main';
 
@@ -20,6 +21,15 @@ function checkEnvironment() {
   if (!supportedPlatforms.includes(platform)) {
     throw new Error(`Platform "${platform}" is not supported`);
   }
+  const requiredVariables = [
+    'GITHUB_WORKSPACE',
+    'RUNNER_ARCH',
+    'RUNNER_OS',
+    'RUNNER_TOOL_CACHE',
+  ];
+  requiredVariables.forEach((variable) => {
+    ok(`${process.env[variable]}`, `Expected ${variable} to be defined`);
+  });
 }
 
 run();


### PR DESCRIPTION
This allows the use of setup-kind on linux/arm64 platform
It adds validation of the required environment variables. 
It validates required fields like version and cluster name. 
It checks that Docker is installed on the server
It prints a warning if a kindest/node is used without sha256. 
It also mutualises the use of the 'kind' constant.
The cache paths now includes the cleaned version of kind and the key hash includes the process arch and the version 

Some thought after this :

Kind repository has also the binaries for linux/ppc64le, windows/amd64, darwin/amd64 and darwin/arm64.

They could be added as supported platforms but some extra work would be required for the cluster creation as kind is only packaged with kindest/node compiled for linux/amd64 and linux/arm64.

The first thing would be to make the image a mandatory input for platforms outside linux/amd64 and linux/arm64. 

Macos-latest doesn't have Docker installed see [the documentation](https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md), So if someone wants to use setup-kind it would be it's responsibility to make sure it is already done when the action starts. 

On windows, kind makes some [warnings here](https://kind.sigs.k8s.io/docs/user/known-issues/#windows-containers) 

My first reaction to those facts is that the opening to each of those platforms can be added only if there is a real requirement for the users. Maybe it's better to wait for kind to package more kindest/node images per platforms 
