### PR TITLE
Update from node12 to node16

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -35,7 +35,7 @@ inputs:
     description: "Silence all stderr output"
     default: "false"
 runs:
-  using: "node12"
+  using: "node16"
   main: "dist/main/index.js"
   post: "dist/post/index.js"
   post-if: success()


### PR DESCRIPTION
GH has deprecated node12 usage in their actions [1] so this PR just
updates the version on the plugin. It has already being forced to do so
by the GH workflow when running.

[1] https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

Signed-off-by: Daniel Mellado <dmellado@redhat.com>