### PR TITLE
use node20 in local GH actions

### DIFF
--- a/.github/workflows/checkin.yml
+++ b/.github/workflows/checkin.yml
@@ -10,6 +10,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           cache: npm
+          node-version: 20
 
       - run: npm install
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,6 +10,7 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           cache: npm
+          node-version: 20
 
       - run: npm install
 


### PR DESCRIPTION
This fixes the GH action failures and kind of fixes #255.

The root cause for #255 is actually the release process. Generating the `./dist` folder has to be done with node-20 and `./node_modules` should not be included in the release.

For a working release check RoadRunnr/setup-kind@1e2bc396f646c7e493975e3802f80588c825e5d0. That repo state was create with `nodejs v20.16.0` on Ubuntu 22.10. I've successfully tested it in a private repository that failed with the json5 problem before.

working for me with `uses: RoadRunnr/setup-kind@1e2bc396f646c7e493975e3802f80588c825e5d0`
